### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
-# jugglingdb-firebird
+## JugglingDB-firebird
 
-Firebird database adapter for JugglingDB
+Firebird database adapter for JugglingDB.
 
 ## Install
 
 	npm install jugglingdb jugglingdb-firebird
 
 ## Usage
-
-```javascript
-var Schema = require('jugglingdb').Schema;
-var schema = new Schema('firebird', {database: "/path/to/database.fdb"});
-
 
 To use it you need `jugglingdb@0.2.x`.
 
@@ -22,7 +17,7 @@ To use it you need `jugglingdb@0.2.x`.
       ...
       "dependencies": {
         "jugglingdb": "0.2.x",
-        "jugglingdb-mysql": "latest"
+        "jugglingdb-firebird": "latest"
       },
       ...
     }
@@ -32,7 +27,7 @@ To use it you need `jugglingdb@0.2.x`.
 
     ```javascript
         var Schema = require('jugglingbd').Schema;
-        var schema = new Schema('mysql', {
+        var schema = new Schema('firebird', {
             database: '/path/to/database.fdb'
         });
     ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,38 @@
 # jugglingdb-firebird
 
-Jugglingdb firebird database adapter
+Firebird database adapter for JugglingDB
 
 ## Install
 
-	npm install jugglingdb-firebird
+	npm install jugglingdb jugglingdb-firebird
 
 ## Usage
 
 ```javascript
 var Schema = require('jugglingdb').Schema;
-var schema = new Schema('jugglingdb-firebird', {database: "/path/to/database.fdb"});
+var schema = new Schema('firebird', {database: "/path/to/database.fdb"});
+
+
+To use it you need `jugglingdb@0.2.x`.
+
+1. Setup dependencies in `package.json`:
+
+    ```json
+    {
+      ...
+      "dependencies": {
+        "jugglingdb": "0.2.x",
+        "jugglingdb-mysql": "latest"
+      },
+      ...
+    }
+    ```
+
+2. Use:
+
+    ```javascript
+        var Schema = require('jugglingbd').Schema;
+        var schema = new Schema('mysql', {
+            database: '/path/to/database.fdb'
+        });
+    ```


### PR DESCRIPTION
Current stable jugglingdb version supports external packages as adapters. Adapter name start with 'jugglingdb-' prefix.
But user should omit it when create schema.

Please take a look at https://github.com/1602/jugglingdb-mongodb as an example of jugglingdb package. Note, that you can use API tests included to jugglingdb core. See: https://github.com/1602/jugglingdb-mongodb/blob/master/test/mongodb.js
